### PR TITLE
#30 #24 #27 Prepare 0.15 for PyPI, add smoke test, improve install howto

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Locate the Python client library hosted at your IQS installation; e.g. the libra
 1. Make sure you have OpenAPI Generator. We have verified that OpenAPI 3.3.4 works; OpenAPI 4+ has some issues. Just download the [.jar](https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/3.3.4/openapi-generator-cli-3.3.4.jar) from the [Mvn Repository](https://mvnrepository.com/artifact/org.openapitools/openapi-generator-cli/3.3.4).   
 1. Locate the OpenAPI definition file (`.yaml`) shipped with your IQS instance. You will find the link in the "*Swagger UI*" tab of the *IncQuery Server Web Console*; e.g. the API definition of the public demo instance is available [here](https://openmbee.incquery.io/iqs4twc.yaml).
 1. Within the OpenAPI definition file, find a line that looks like `version: 0.16.0`; it will be found near the top, below `info:`. This version number is the API version of your IQS installation.
-1. At the end of the OpenAPI definition file, append a few lines (continuing the section `components:` and then adding a new section `security:`) to specify the authentication method of your IQS instance. For instance, in case of basic authentication, you would add these lines: 
+1. At the end of the OpenAPI definition file, append a few lines (continuing the section `components:` and then adding a new section `security:`) to specify the authentication method of your IQS instance. Be mindful of proper indentation. For instance, in case of basic authentication, you would add these lines: 
  
          securitySchemes:
            basicAuth:

--- a/README.md
+++ b/README.md
@@ -21,9 +21,13 @@ Click the __binder__ shield above to spin up a deployment publicly hosted on [My
 
 ## Getting started 
 
-Assuming that you have cloned this repository to your computer at path `${this-git-repo}`, the following instructions will help you get the Jupyter extensions running.
+Assuming that you have cloned this repository to your computer at path `${this-git-repo}`, the following instructions will help you get the Jupyter extensions for IQS running. As a main dependency, this involves the installation of the (automatically generated) Python-based IQS API client. 
 
-### Using Conda 
+### Prerequisites 
+
+For first-time users, we generally recommend Miniconda3/Anaconda and `conda` (see below), but it is possible to do without. 
+
+#### Installing Jupyter using Conda 
 
 1. Make sure Miniconda3/Anaconda is installed, along with Python 3.7+ and the `conda` package manager 
 1. Make sure Jupyter is installed: 
@@ -31,13 +35,67 @@ Assuming that you have cloned this repository to your computer at path `${this-g
         conda install jupyter
         
     See details at: [jupyter.org](https://jupyter.org/install)
-    
-1. The main dependency of the Jupyter client extension is the automatically generated Python-based IQS API client. Locate the Python client library hosted at your IQS installation; e.g. the library accompanying the public IQS demo server is available at https://openmbee.incquery.io/client/incqueryserver-api-python-client-0.11.0.tar.gz for installation. Install this *sdist* using `pip` from your Anaconda console:
+
+#### Installing Jupyter using `pip`
+
+If you already have Python 3.7+, you can alternatively use the `pip` package manager to acquire Jupyter and install the rest of the packages. 
+
+        pip install jupyter
+        
+
+### Installing the Python-based IQS API client
+
+#### Release version from public repository 
+
+Currently builds are available [from PyPI](https://test.pypi.org/project/incqueryserver-api-python-client/).
+
+        pip install incqueryserver-api-python-client
+
+Conda package builds will be available in the future. 
+
+Note that these publicly available builds have been generated to support basic authentication. If your IQS instance uses another authentication method, you need to install the package build shipped with your IQS instance.
+
+#### Version supplied with IQS instance  
+
+Locate the Python client library hosted at your IQS installation; e.g. the library accompanying the public IQS demo server is available at https://openmbee.incquery.io/client/ for installation; copy the link to the actual package archive (*sdist*) file. Install this *sdist* using `pip`. If you are using Anaconda, make sure to issue the below command line from your Anaconda console.
 
         pip install ${address-of-python-client-sdist}
 
-1. Designate a location as the notebook home, where notebook files will be stored. For example, use `${this-git-repo}/example-notebook-home`.
-1. Ensure that the non-generated Jupyter-specific client extensions are available to notebooks by executing ONE of the following options: 
+#### Roll your own: generate Python client for your own IQS instance   
+
+
+1. Make sure you have OpenAPI Generator. We have verified that OpenAPI 3.3.4 works; OpenAPI 4+ has some issues. Just download the [.jar](https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/3.3.4/openapi-generator-cli-3.3.4.jar) from the [Mvn Repository](https://mvnrepository.com/artifact/org.openapitools/openapi-generator-cli/3.3.4).   
+1. Locate the OpenAPI definition file (`.yaml`) shipped with your IQS instance. You will find the link in the "*Swagger UI*" tab of the *IncQuery Server Web Console*; e.g. the API definition of the public demo instance is available [here](https://openmbee.incquery.io/iqs4twc.yaml).
+1. Within the OpenAPI definition file, look for a line looking like `version: 0.16.0` near the top, below `info:`. This version number is the API version of your IQS installation.
+1. Generate a Python API into `${this-git-repo}/source-gen/incqueryserver-api-python-client` using the following command line:
+ 
+            java -jar ${path-to-OpenAPI/openapi-generator-cli-3.3.4.jar} generate -i ${path-to-API-definition-yaml} -g python -o ${this-git-repo}/source-gen/incqueryserver-api-python-client -DpackageVersion="${API-version-of-your-IQS-instance}" -DpackageUrl="https://incquery.io" -DpackageName=iqs_client -DprojectName=incqueryserver-api-python-client  
+
+1. Ensure that the generated Python client implementation is available to notebooks by executing ONE of the following options: 
+   * For end users: 
+
+            pip install ${this-git-repo}/source/incqueryserver-jupyter
+
+   * For IQS developers who repeatedly edit the `.yaml` definition file and regenerate the Python code: issue one of the following commands to perform a "developer" install directly from the generated source project; changes to the source will be reflected immediately to newly (re)started Python interpreters / Jupyter kernels (previously started kernels that already executed the `import` will keep the old content until restarted). Select the appropriate command line depending whether you use `pip` or `conda`.
+
+            pip install -e ${this-git-repo}/source-gen/incqueryserver-api-python-client
+            conda develop ${this-git-repo}/source-gen/incqueryserver-api-python-client
+
+Note: the generated client will only include the Acquisition API in versions 0.16 and above.
+
+### Installing the Jupyter-specific client extensions
+
+#### Release version from public repository 
+
+Currently builds are available [from PyPI](https://test.pypi.org/project/incqueryserver-api-python-client/).
+
+        pip install incqueryserver-jupyter
+
+Conda package builds will be available in the future. 
+
+#### Install from source using Conda 
+
+Ensure that the non-generated Jupyter-specific client extensions are available to notebooks by executing ONE of the following options: 
    * For end users: (in the Anaconda console environment) build a conda package from the client extensions sources, then install it:
 
             conda build ${this-git-repo}/releng/iqs-jupyter-packaging/conda/incqueryserver-jupyter
@@ -47,17 +105,32 @@ Assuming that you have cloned this repository to your computer at path `${this-g
 
             conda develop ${this-git-repo}/source/incqueryserver-jupyter
 
-### Using `pip` instead of Conda
+#### Install from source using `pip`
 
-The above instructions mostly apply here as well. However, instead of issuing `conda build` and `conda install` on the conda recipe directories, run instead 
+Ensure that the non-generated Jupyter-specific client extensions are available to notebooks by executing ONE of the following options: 
+   * For end users: 
 
     pip install ${this-git-repo}/source/incqueryserver-jupyter
 
-Specifying `install -e` will install these pip packages in "editable" mode, similarly to `conda develop`.
+   * For developers: issue the following command to perform a "developer" install directly from the source project; changes to the source will be reflected immediately to newly (re)started Python interpreters / Jupyter kernels (previously started kernels that already executed the `import` will keep the old content until restarted).
+
+    pip install -e ${this-git-repo}/source/incqueryserver-jupyter
 
 Note that since we rely on `conda` packaging by default, the dependencies may have to be installed manually in case of using `pip`.
 
-### Additional dependencies
+### Final steps
+
+Whether you installed from source or from the public repository, it is a good idea to verify your installation. Also, you might need a few additional components if you want to run our demo notebooks.
+
+#### Smoke test
+
+Run [test_iqs_client.py](https://github.com/IncQueryLabs/incquery-server-jupyter/blob/master/test-scripts/test_iqs_client.py) and [test_iqs_jupyter.py](https://github.com/IncQueryLabs/incquery-server-jupyter/blob/master/test-scripts/test_iqs_jupyter.py) as a quick smoke test to verify correct installation of the generated client package and the Jupyter extensions package, respectively.
+
+        python ${this-git-repo}/test-scripts/test_iqs_client.py
+        python ${this-git-repo}/test-scripts/test_iqs_jupyter.py
+
+
+#### Additional dependencies
 
 The demo notebook uses `plotly` and `cufflinks` to demonstrate possible applications of the client extensions package. It is not recommended to install `cufflinks-py` using conda, as conda-forge seems to host an obsolete version not compatible with the demo; simply issue `pip install cufflinks` from the Anaconda console instead. 
 
@@ -65,7 +138,7 @@ The direct connection to the MMS server additionally requires the installation o
 
 ## Running the notebook
 
-### Set up environment variables first
+### Optional: set up environment variables first
   
 Several functions and classes defined in client extension take optional arguments whose default values can be injected via environment variables. This allows the notebook itself to be much simpler, by omitting connection data etc. 
 
@@ -100,6 +173,7 @@ A similar shell script can be used in case of *nix systems; a docker file might 
 
 ### Run the notebook
 
+1. Designate a location as the notebook home, where notebook files will be stored. For example, use `${this-git-repo}/example-notebook-home`.
 1. (in the Anaconda console environment) start a Jupyter server from `${path-to-notebook-home}`: 
 ```jupyter notebook```
 1. Interact with Jupyter either via the newly opened browser window, or using the URL or token printed by the Jupyter server to its stdout. Create a new notebook or open an existing one within the notebook folder; see an example in `${this-git-repo}/example-notebook-home/iqs-demo-twc.ipynb` (if the parent folder is designated as notebook home, you should already see this notebook as a starting point).
@@ -120,7 +194,7 @@ A similar shell script can be used in case of *nix systems; a docker file might 
       
                 iqs = iqs_jupyter.connect()
        
-   1. Browse for a TWC revision using 
+   1. You can now interact with the IQS instance. For instance, if your IQS installation is connected to TWC, browse for a TWC revision using 
    
             revision_selector = iqs.jupyter_tools.twc_revision_selector_widget()
    

--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ Locate the Python client library hosted at your IQS installation; e.g. the libra
 1. Make sure you have OpenAPI Generator. We have verified that OpenAPI 3.3.4 works; OpenAPI 4+ has some issues. Just download the [.jar](https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/3.3.4/openapi-generator-cli-3.3.4.jar) from the [Mvn Repository](https://mvnrepository.com/artifact/org.openapitools/openapi-generator-cli/3.3.4).   
 1. Locate the OpenAPI definition file (`.yaml`) shipped with your IQS instance. You will find the link in the "*Swagger UI*" tab of the *IncQuery Server Web Console*; e.g. the API definition of the public demo instance is available [here](https://openmbee.incquery.io/iqs4twc.yaml).
 1. Within the OpenAPI definition file, find a line that looks like `version: 0.16.0`; it will be found near the top, below `info:`. This version number is the API version of your IQS installation.
+1. At the end of the OpenAPI definition file, append a few lines (continuing the section `components:` and then adding a new section `security:`) to specify the authentication method of your IQS instance. For instance, in case of basic authentication, you would add these lines: 
+ 
+         securitySchemes:
+           basicAuth:
+             type: http
+             scheme: basic       
+       
+       security:
+         - basicAuth: []
+
 1. Generate a Python API into `${this-git-repo}/source-gen/incqueryserver-api-python-client` using the following command line:
  
             java -jar ${path-to-OpenAPI/openapi-generator-cli-3.3.4.jar} generate -i ${path-to-API-definition-yaml} -g python -o ${this-git-repo}/source-gen/incqueryserver-api-python-client -DpackageVersion="${API-version-of-your-IQS-instance}" -DpackageUrl="https://incquery.io" -DpackageName=iqs_client -DprojectName=incqueryserver-api-python-client  

--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ If you already have Python 3.7+, you can alternatively use the `pip` package man
 
 ### Installing the Python-based IQS API client
 
+You must install the generated Python client package by executing ONE of the following options.
+
 #### Release version from public repository 
 
-Currently builds are available [from PyPI](https://test.pypi.org/project/incqueryserver-api-python-client/).
+Currently builds are available [from PyPI](https://pypi.org/project/incqueryserver-api-python-client/).
 
         pip install incqueryserver-api-python-client
 
@@ -66,7 +68,7 @@ Locate the Python client library hosted at your IQS installation; e.g. the libra
 
 1. Make sure you have OpenAPI Generator. We have verified that OpenAPI 3.3.4 works; OpenAPI 4+ has some issues. Just download the [.jar](https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/3.3.4/openapi-generator-cli-3.3.4.jar) from the [Mvn Repository](https://mvnrepository.com/artifact/org.openapitools/openapi-generator-cli/3.3.4).   
 1. Locate the OpenAPI definition file (`.yaml`) shipped with your IQS instance. You will find the link in the "*Swagger UI*" tab of the *IncQuery Server Web Console*; e.g. the API definition of the public demo instance is available [here](https://openmbee.incquery.io/iqs4twc.yaml).
-1. Within the OpenAPI definition file, look for a line looking like `version: 0.16.0` near the top, below `info:`. This version number is the API version of your IQS installation.
+1. Within the OpenAPI definition file, find a line that looks like `version: 0.16.0`; it will be found near the top, below `info:`. This version number is the API version of your IQS installation.
 1. Generate a Python API into `${this-git-repo}/source-gen/incqueryserver-api-python-client` using the following command line:
  
             java -jar ${path-to-OpenAPI/openapi-generator-cli-3.3.4.jar} generate -i ${path-to-API-definition-yaml} -g python -o ${this-git-repo}/source-gen/incqueryserver-api-python-client -DpackageVersion="${API-version-of-your-IQS-instance}" -DpackageUrl="https://incquery.io" -DpackageName=iqs_client -DprojectName=incqueryserver-api-python-client  
@@ -85,9 +87,11 @@ Note: the generated client will only include the Acquisition API in versions 0.1
 
 ### Installing the Jupyter-specific client extensions
 
+You must install the Jupyter support itself by executing ONE of the following options.
+
 #### Release version from public repository 
 
-Currently builds are available [from PyPI](https://test.pypi.org/project/incqueryserver-api-python-client/).
+Currently builds are available [from PyPI](https://pypi.org/project/incqueryserver-jupyter/).
 
         pip install incqueryserver-jupyter
 
@@ -98,8 +102,8 @@ Conda package builds will be available in the future.
 Ensure that the non-generated Jupyter-specific client extensions are available to notebooks by executing ONE of the following options: 
    * For end users: (in the Anaconda console environment) build a conda package from the client extensions sources, then install it:
 
-            conda build ${this-git-repo}/releng/iqs-jupyter-packaging/conda/incqueryserver-jupyter
-            conda install --use-local incqueryserver-jupyter
+            conda build -c conda-forge ${this-git-repo}/releng/iqs-jupyter-packaging/conda/incqueryserver-jupyter
+            conda install -c conda-forge --use-local incqueryserver-jupyter
 
    * For developers: issue the following command to perform a "developer" install directly from the source project; changes to the source will be reflected immediately to newly (re)started Python interpreters / Jupyter kernels (previously started kernels that already executed the `import` will keep the old content until restarted).
 
@@ -134,7 +138,7 @@ Run [test_iqs_client.py](https://github.com/IncQueryLabs/incquery-server-jupyter
 
 The demo notebook uses `plotly` and `cufflinks` to demonstrate possible applications of the client extensions package. It is not recommended to install `cufflinks-py` using conda, as conda-forge seems to host an obsolete version not compatible with the demo; simply issue `pip install cufflinks` from the Anaconda console instead. 
 
-The direct connection to the MMS server additionally requires the installation of `mms-python-client`.
+The direct connection to the MMS server additionally requires the installation of `mms-python-client`; you might have missed this dependency if you installed the Jupyter extensions in development mode.
 
 ## Running the notebook
 
@@ -194,9 +198,9 @@ A similar shell script can be used in case of *nix systems; a docker file might 
       
                 iqs = iqs_jupyter.connect()
        
-   1. You can now interact with the IQS instance. For instance, if your IQS installation is connected to TWC, browse for a TWC revision using 
+   1. You can now interact with the IQS instance. For example, if your IQS installation is connected to MMS, browse for an MMS commit using 
    
-            revision_selector = iqs.jupyter_tools.twc_revision_selector_widget()
+            commit_selector = iqs.jupyter_tools.mms_commit_selector_widget()
    
    1. Access the full JSON/RPC API of IQS in the form of (you may use TAB completion):
    

--- a/releng/iqs-jupyter-packaging/conda/incqueryserver-api-python-client/meta.yaml
+++ b/releng/iqs-jupyter-packaging/conda/incqueryserver-api-python-client/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: incqueryserver-api-python-client 
-  version: "0.16.0"
+  version: "0.15.0"
 
 source:
   path: ../../../../source-gen/incqueryserver-api-python-client
@@ -29,6 +29,7 @@ requirements:
 test:
   imports:
     - iqs_client
+    - iqs_connector_client
 
 about:
   home: https://incquery.io

--- a/releng/iqs-jupyter-packaging/conda/incqueryserver-jupyter/meta.yaml
+++ b/releng/iqs-jupyter-packaging/conda/incqueryserver-jupyter/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: incqueryserver-jupyter
-  version: "0.16.0"
+  version: "0.15.0"
 
 source:
   path: ../../../../source/incqueryserver-jupyter
@@ -15,14 +15,13 @@ requirements:
     - python
     - setuptools
     - incqueryserver-api-python-client
-    - incqueryserver-connector-api-python-client
     - ipywidgets
     - requests
+    - mms-python-client
 
   run:
     - python
     - incqueryserver-api-python-client
-    - incqueryserver-connector-api-python-client
     - ipywidgets
     - requests
     - mms-python-client

--- a/source/incqueryserver-jupyter/.gitignore
+++ b/source/incqueryserver-jupyter/.gitignore
@@ -1,0 +1,2 @@
+/build/
+/dist/

--- a/source/incqueryserver-jupyter/iqs_jupyter/about.py
+++ b/source/incqueryserver-jupyter/iqs_jupyter/about.py
@@ -20,4 +20,4 @@ Created on 2019. máj. 24.
 
 # single-sourcing of version string
 # see solution 3 @ https://packaging.python.org/guides/single-sourcing-package-version
-__version__ = "0.16.0"
+__version__ = "0.15.0"

--- a/source/incqueryserver-jupyter/setup.py
+++ b/source/incqueryserver-jupyter/setup.py
@@ -28,7 +28,7 @@ version = {}
 with open("iqs_jupyter/about.py") as fp:
     exec(fp.read(), version)
 
-REQUIRES = ["incqueryserver-api-python-client"]
+REQUIRES = ["incqueryserver-api-python-client", "mms-python-client"]
 
 setuptools.setup(
     name="incqueryserver-jupyter",
@@ -43,7 +43,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     classifiers=[
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: Apache License",
+        "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
 )

--- a/test-scripts/.project
+++ b/test-scripts/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>test-scripts</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.python.pydev.PyDevBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.python.pydev.pythonNature</nature>
+	</natures>
+</projectDescription>

--- a/test-scripts/.pydevproject
+++ b/test-scripts/.pydevproject
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?eclipse-pydev version="1.0"?><pydev_project>
+<pydev_property name="org.python.pydev.PYTHON_PROJECT_INTERPRETER">Default</pydev_property>
+<pydev_pathproperty name="org.python.pydev.PROJECT_SOURCE_PATH">
+<path>/${PROJECT_DIR_NAME}</path>
+</pydev_pathproperty>
+<pydev_property name="org.python.pydev.PYTHON_PROJECT_VERSION">python interpreter</pydev_property>
+</pydev_project>

--- a/test-scripts/test_iqs_client.py
+++ b/test-scripts/test_iqs_client.py
@@ -1,0 +1,25 @@
+'''
+Created on 2020. jún. 11.
+
+@author: Gabor Bergmann
+'''
+import unittest
+
+
+class IQSJupyterExtensionsTest(unittest.TestCase):
+
+    def testImport(self):
+        import iqs_jupyter
+
+    def testStatusOfDemoInstance(self):
+        import iqs_jupyter
+        
+        iqs = iqs_jupyter.connect("https://openmbee.incquery.io", "openmbeeguest", "guest")
+                
+        status = iqs.server_management.get_server_status()
+        
+        self.assertIn('SERVER', status.component_statuses)
+
+if __name__ == "__main__":
+    #import sys;sys.argv = ['', 'Test.testName']
+    unittest.main()

--- a/test-scripts/test_iqs_jupyter.py
+++ b/test-scripts/test_iqs_jupyter.py
@@ -1,0 +1,36 @@
+'''
+Created on 2020. jún. 11.
+
+@author: Gabor Bergmann
+'''
+import unittest
+
+
+class IQSClientTest(unittest.TestCase):
+
+    def testImport(self):
+        import iqs_client
+        import iqs_connector_client
+
+
+    '''
+        Simple test courtesy of Ábel Hegedüs
+    '''
+    def testStatusOfDemoInstance(self):
+        import iqs_client
+        
+        iqs_configuration = iqs_client.Configuration()
+        iqs_configuration.host = "https://openmbee.incquery.io/api"
+        iqs_configuration.username = "openmbeeguest"
+        iqs_configuration.password = "guest"
+        
+        iqs = iqs_client.ApiClient(iqs_configuration)
+        server_management_api = iqs_client.ServerManagementApi(iqs)
+        
+        status = server_management_api.get_server_status()
+        
+        self.assertIn('SERVER', status.component_statuses)
+
+if __name__ == "__main__":
+    #import sys;sys.argv = ['', 'Test.testName']
+    unittest.main()


### PR DESCRIPTION
Prepared 0.15 release packages ready for distribution. Also tested with `conda build` (hence the recipe updates). Adjusted documentation to reflect that end-user will, from now on, install packages by default from PyPI.

Note: at the moment, the packages are not available from the main PyPI yet, only from the *Test PyPI*.

A few minor issues are coincidentally resolved by the documentation rewrite:
 * Closes #24 
 * Closes #27