### PR TITLE
Fix display issue of the IQS connection widget

### DIFF
--- a/source/incqueryserver-jupyter/iqs_jupyter/authentication.py
+++ b/source/incqueryserver-jupyter/iqs_jupyter/authentication.py
@@ -119,7 +119,7 @@ class IQSConnectorWidget:
             self.display()
 
     def display(self):
-        display(tuple([self.box]))
+        display(self.box)
 
     def _repr_html_(self):
         self.display()


### PR DESCRIPTION
The IDE warns that the display function expects a tuple. I wrapped the self.box into a tuple to fix this warning. Instead, the tuple is displayed as a string. Reverted this change.
Closes #54