### PR TITLE
#62 MV Link generation from IQS client & API call

### DIFF
--- a/source/incqueryserver-jupyter/iqs_jupyter/analysis_extensions.py
+++ b/source/incqueryserver-jupyter/iqs_jupyter/analysis_extensions.py
@@ -145,7 +145,9 @@ def _monkey_patch_analysis_result_repr_html(self : iqs_client.AnalysisResult, he
     param_headers = " ".join(["<th>{}</th> ".format(html.escape(param)) for param in pattern_params])
     match_rows = "\n".join([
         "<tr><th>{}</th><td>{}</td>{}</tr>\n".format(row_index, self.matches[row_index].message, " ".join([
-            " <td>{} <a href=\"{}\">LINK</a></td>".format(_cell_to_html(_dict_to_element(argument_value.value)), _create_model_viewer_link(argument_value.value['element']))  # copartmentURI és relativeElementID
+            " <td><a href=\"{}\">{}</a></td>".format(
+                _dict_to_element(argument_value.value).url,
+                _cell_to_html(_dict_to_element(argument_value.value)))
             for argument_value in self.matches[row_index].matching_elements
         ])) for row_index in range(len(self.matches))
     ])
@@ -169,19 +171,6 @@ def _monkey_patch_analysis_result_repr_html(self : iqs_client.AnalysisResult, he
         </table>
         </div>
     '''.format(header_report, style, param_headers, match_rows)
-
-from iqs_jupyter.authentication import IQSConnectorWidget
-import requests
-
-def _create_model_viewer_link(element):
-    # iqs_host = self.configuration
-    # req = requests.get(iqs_host+"/api/web-console-config")
-    # start = req.json()["modelViewerBaseURL"]
-    start = "127.0.0.1:8080/"
-    compURI = element['compartmentURI']
-    relElementID = element['relativeElementID']
-
-    return start + '?compartmentURI='+compURI+'&elementId='+relElementID
 
 def _do_monkey_patching():
     iqs_client.AnalysisResults._repr_html_ = _monkey_patch_analysis_results_repr_html

--- a/source/incqueryserver-jupyter/iqs_jupyter/analysis_extensions.py
+++ b/source/incqueryserver-jupyter/iqs_jupyter/analysis_extensions.py
@@ -145,7 +145,7 @@ def _monkey_patch_analysis_result_repr_html(self : iqs_client.AnalysisResult, he
     param_headers = " ".join(["<th>{}</th> ".format(html.escape(param)) for param in pattern_params])
     match_rows = "\n".join([
         "<tr><th>{}</th><td>{}</td>{}</tr>\n".format(row_index, self.matches[row_index].message, " ".join([
-            " <td>{}</td>".format(_cell_to_html(_dict_to_element(argument_value.value))) 
+            " <td>{} <a href=\"{}\">LINK</a></td>".format(_cell_to_html(_dict_to_element(argument_value.value)), _create_model_viewer_link(argument_value.value['element']))  # copartmentURI és relativeElementID
             for argument_value in self.matches[row_index].matching_elements
         ])) for row_index in range(len(self.matches))
     ])
@@ -170,7 +170,18 @@ def _monkey_patch_analysis_result_repr_html(self : iqs_client.AnalysisResult, he
         </div>
     '''.format(header_report, style, param_headers, match_rows)
 
+from iqs_jupyter.authentication import IQSConnectorWidget
+import requests
 
+def _create_model_viewer_link(element):
+    # iqs_host = self.configuration
+    # req = requests.get(iqs_host+"/api/web-console-config")
+    # start = req.json()["modelViewerBaseURL"]
+    start = "127.0.0.1:8080/"
+    compURI = element['compartmentURI']
+    relElementID = element['relativeElementID']
+
+    return start + '?compartmentURI='+compURI+'&elementId='+relElementID
 
 def _do_monkey_patching():
     iqs_client.AnalysisResults._repr_html_ = _monkey_patch_analysis_results_repr_html

--- a/source/incqueryserver-jupyter/iqs_jupyter/authentication.py
+++ b/source/incqueryserver-jupyter/iqs_jupyter/authentication.py
@@ -22,6 +22,8 @@ import iqs_jupyter.tool_extension_point as ext_point
 from iqs_jupyter import api_composition
 from iqs_client_extension import ApiClientWithOIDC
 
+import requests
+
 
 def connect(
         address=defaults.default_IQS_address,
@@ -57,8 +59,6 @@ def connect(
         configuration.access_token = token
 
     return IQSClient(configuration, use_oidc)
-
-import requests
 
 class IQSClient:
     def __init__(

--- a/source/incqueryserver-jupyter/iqs_jupyter/authentication.py
+++ b/source/incqueryserver-jupyter/iqs_jupyter/authentication.py
@@ -41,6 +41,7 @@ def connect(
         configuration.access_token = token
     return IQSClient(configuration, use_oidc)
 
+import requests
 
 class IQSClient:
     def __init__(
@@ -54,6 +55,43 @@ class IQSClient:
             api_composition.decorate_iqs_client(self, root_configuration, ApiClient)
         self.jupyter_tools = ext_point.IQSJupyterTools(self)
 
+        # Acquiring Model Viewer base link from host through internal API
+        req = requests.get(f"http://{root_configuration.host}/api/web-console-config")
+
+        # Creating ModelViwer url holder to persist link
+        self.mv_url = ModelViewerUrlProvider(self, req.json()["modelViewerBaseURL"])
+
+        # Url provider registering, a function to provide Model Viewer links
+        ext_point.url_providers.append(self.mv_url.as_url_provider())
+        ext_point.url_providers.append(ModelViewerUrlProvider(self, req.json()["modelViewerBaseURL"]))
+
+class ModelViewerUrlProvider:
+    def __init__(self, iqs, mv_address=None):
+        self.mv_address = mv_address
+        self.iqs = iqs
+
+    def __call__(self, element):
+        if "compartmentURI" in element and "relativeElementID" in element:
+            # Creating ModelViewer Link
+            compURI = element['compartmentURI']
+            relElementID = element['relativeElementID']
+            return f"{self.mv_address}?compartmentURI={compURI}&elementId={relElementID}"
+        else:
+            return None
+
+    def as_url_provider(self):
+        def url_provider(element_descriptor):
+            return self.element_api_link(element_descriptor)
+        return url_provider
+
+    def element_api_link(self, element):
+        if "compartmentURI" in element and "relativeElementID" in element:
+            # Creating ModelViewer Link
+            compURI = element['compartmentURI']
+            relElementID = element['relativeElementID']
+            return f"{self.mv_address}?compartmentURI={compURI}&elementId={relElementID}"
+        else:
+            return None
 
 class IQSConnectorWidget:
     def __init__(

--- a/source/incqueryserver-jupyter/iqs_jupyter/authentication.py
+++ b/source/incqueryserver-jupyter/iqs_jupyter/authentication.py
@@ -56,42 +56,12 @@ class IQSClient:
         self.jupyter_tools = ext_point.IQSJupyterTools(self)
 
         # Acquiring Model Viewer base link from host through internal API
-        req = requests.get(f"http://{root_configuration.host}/api/web-console-config")
+        req = requests.get(f"http://{root_configuration.host}/internal-api/solution-configuration")
 
-        # Creating ModelViwer url holder to persist link
-        self.mv_url = ModelViewerUrlProvider(self, req.json()["modelViewerBaseURL"])
+        # Registering MV URL provider, providing links to MV link received from API call above
+        ext_point.url_providers.append(ext_point.ModelViewerUrlProvider(self, req.json()["modelViewerBaseURL"]))
 
-        # Url provider registering, a function to provide Model Viewer links
-        ext_point.url_providers.append(self.mv_url.as_url_provider())
-        ext_point.url_providers.append(ModelViewerUrlProvider(self, req.json()["modelViewerBaseURL"]))
 
-class ModelViewerUrlProvider:
-    def __init__(self, iqs, mv_address=None):
-        self.mv_address = mv_address
-        self.iqs = iqs
-
-    def __call__(self, element):
-        if "compartmentURI" in element and "relativeElementID" in element:
-            # Creating ModelViewer Link
-            compURI = element['compartmentURI']
-            relElementID = element['relativeElementID']
-            return f"{self.mv_address}?compartmentURI={compURI}&elementId={relElementID}"
-        else:
-            return None
-
-    def as_url_provider(self):
-        def url_provider(element_descriptor):
-            return self.element_api_link(element_descriptor)
-        return url_provider
-
-    def element_api_link(self, element):
-        if "compartmentURI" in element and "relativeElementID" in element:
-            # Creating ModelViewer Link
-            compURI = element['compartmentURI']
-            relElementID = element['relativeElementID']
-            return f"{self.mv_address}?compartmentURI={compURI}&elementId={relElementID}"
-        else:
-            return None
 
 class IQSConnectorWidget:
     def __init__(

--- a/source/incqueryserver-jupyter/iqs_jupyter/core_extensions.py
+++ b/source/incqueryserver-jupyter/iqs_jupyter/core_extensions.py
@@ -70,8 +70,6 @@ def _recognize_typed_element_in_compartment_descriptor(
 ext_point.element_dict_recognizers.append(_recognize_typed_element_in_compartment_descriptor)
 
 
-
-
 ## monkey patch section
 
 def _monkey_patch_element_in_compartment_descriptor_repr_html(self):
@@ -250,7 +248,7 @@ def _monkey_patch_query_execution_response_to_html(self):
     param_headers = " ".join(["<th>{}</th> ".format(html.escape(param)) for param in pattern_params])
     match_rows = "\n".join([
         "<tr><th>{}</th>{}</tr>\n".format(row_index," ".join([
-            " <td>{}</td>".format(_cell_to_html(match_list[row_index][param])) for param in pattern_params
+            " <td><a href=\"{}\">{}</a></td>".format(_cell_to_html(match_list[row_index][param]).url, _cell_to_html(match_list[row_index][param])) for param in pattern_params
         ])) for row_index in range(len(match_list))
     ])
     

--- a/source/incqueryserver-jupyter/iqs_jupyter/helpers.py
+++ b/source/incqueryserver-jupyter/iqs_jupyter/helpers.py
@@ -31,16 +31,30 @@ def cell_to_html(cell):
     else:
         return str(cell)
 
-def dict_to_element(dict_or_attribute_value, url_provider=None):
+def dict_to_element(dict_or_attribute_value):
     if isinstance(dict_or_attribute_value, dict):
         for recognizer in ext_point.element_dict_recognizers:
             recognized = recognizer(dict_or_attribute_value)
             if recognized:
-                if url_provider is not None:
-                    recognized.url = url_provider(recognized)
+                for url_provider in ext_point.url_providers:
+                    if url_provider(dict_or_attribute_value['element']) is not None: # maybe we should set url param to None - else
+                        setattr(recognized, 'url', url_provider(dict_or_attribute_value['element']))
                 return recognized
-        # not recognized as an element, treated as raw dict    
+        # not recognized as an element, treated as raw dict
         return dict_or_attribute_value
     else:
         return dict_or_attribute_value
+
+# def dict_to_element(dict_or_attribute_value, url_provider=None):
+#     if isinstance(dict_or_attribute_value, dict):
+#         for recognizer in ext_point.element_dict_recognizers:
+#             recognized = recognizer(dict_or_attribute_value)
+#             if recognized:
+#                 if url_provider is not None:
+#                     recognized.url = url_provider(recognized)
+#                 return recognized
+#         # not recognized as an element, treated as raw dict
+#         return dict_or_attribute_value
+#     else:
+#         return dict_or_attribute_value
 

--- a/source/incqueryserver-jupyter/iqs_jupyter/tool_extension_point.py
+++ b/source/incqueryserver-jupyter/iqs_jupyter/tool_extension_point.py
@@ -37,3 +37,16 @@ element_dict_recognizers : List[Callable[[dict], Optional[Any]]] = []
 
 url_providers: List[Callable[[Any], Optional[Any]]] = []
 
+class ModelViewerUrlProvider:
+    def __init__(self, iqs, mv_address=None):
+        self.mv_address = mv_address
+        self.iqs = iqs
+
+    def __call__(self, element):
+        if "compartmentURI" in element and "relativeElementID" in element:
+            # Creating ModelViewer Link
+            compURI = element['compartmentURI']
+            relElementID = element['relativeElementID']
+            return f"{self.mv_address}?compartmentURI={compURI}&elementId={relElementID}"
+        else:
+            return None

--- a/source/incqueryserver-jupyter/iqs_jupyter/tool_extension_point.py
+++ b/source/incqueryserver-jupyter/iqs_jupyter/tool_extension_point.py
@@ -29,8 +29,11 @@ class IQSJupyterTools:
         self._iqs = iqs
 
 
-# connector-specific extensions may add custom ways to convert a dict to an element representation; 
+# connector-specific extensions may add custom ways to convert a dict to an element representation;
 #     parse a dict and return the constructed element or None if not the right format
-#     default is ElementInCompartmentDescriptor 
+#     default is ElementInCompartmentDescriptor
 element_dict_recognizers : List[Callable[[dict], Optional[Any]]] = []
+
+
+url_providers: List[Callable[[Any], Optional[Any]]] = []
 


### PR DESCRIPTION
FIxes #62 

Changes:
- Obtain ModelViewer solution link from IQS connection
- Created an URL provider which uses this link to create MV links for elements
- Modified report generation to create links for elements to be viewed in MV